### PR TITLE
Allow TTL events to display in LFP Viewer

### DIFF
--- a/NetworkEvents/Source/NetworkEvents.cpp
+++ b/NetworkEvents/Source/NetworkEvents.cpp
@@ -83,8 +83,7 @@ void NetworkEvents::restartConnection()
 
 void NetworkEvents::createEventChannels()
 {
-    float sampleRate = CoreServices::getGlobalSampleRate();
-    EventChannel* chan = new EventChannel(EventChannel::TEXT, 1, MAX_MESSAGE_LENGTH, sampleRate, this);
+    EventChannel* chan = new EventChannel(EventChannel::TEXT, 1, MAX_MESSAGE_LENGTH, 0, this);
 	chan->setName("Network messages");
 	chan->setDescription("Messages received through the network events module");
 	chan->setIdentifier("external.network.rawData");
@@ -93,7 +92,7 @@ void NetworkEvents::createEventChannels()
 	eventChannelArray.add(chan);
 	messageChannel = chan;
 
-    EventChannel* TTLchan = new EventChannel(EventChannel::TTL, 8, 1, sampleRate, this);
+    EventChannel* TTLchan = new EventChannel(EventChannel::TTL, 8, 1, 0, this);
     TTLchan->setName("Network Events output");
     TTLchan->setDescription("Triggers whenever \"TTL\" is received on the port.");
     TTLchan->setIdentifier("external.network.ttl");


### PR DESCRIPTION
With PR open-ephys/plugin-GUI#303, this marks the Network Events channels as not corresponding to continuous data and lets the TTL events be displayed in the LFP viewer regardless of what subprocessor is selected. See that PR for details.