### PR TITLE
Fix ports sometimes not being unbound in time when loading a signal chain

### DIFF
--- a/EventBroadcaster/Source/EventBroadcaster.h
+++ b/EventBroadcaster/Source/EventBroadcaster.h
@@ -23,6 +23,7 @@
 #endif
 
 class EventBroadcaster : public GenericProcessor
+                       , private AsyncUpdater
 {
 public:
     // ids for format combobox
@@ -34,7 +35,7 @@ public:
 
     int getListeningPort() const;
     // returns 0 on success, else the errno value for the error that occurred.
-    int setListeningPort(int port, bool forceRestart = false);
+    int setListeningPort(int port, bool forceRestart = false, bool searchForPort = false, bool synchronous = true);
 
     int getOutputFormat() const;
     void setOutputFormat(int format);
@@ -92,6 +93,8 @@ private:
     static void populateMetaData(const MetaDataEventObject* channel,
         const EventBasePtr event, DynamicObject::Ptr dest);
 
+    void handleAsyncUpdate() override; // to change port asynchronously
+
     static String getEndpoint(int port);
 
     // called from setListeningPort() depending on success/failure of ZMQ operations
@@ -118,6 +121,11 @@ private:
     static var stringValueToVar(const void* value, unsigned int dataLength);
 
     static DataToVarFcn getDataReader(BaseType dataType);
+
+    // for setting port asynchronously
+    int asyncPort;
+    bool asyncForceRestart;
+    bool asyncSearchForPort;
 };
 
 

--- a/NetworkEvents/Source/NetworkEvents.cpp
+++ b/NetworkEvents/Source/NetworkEvents.cpp
@@ -38,12 +38,13 @@ const int MAX_MESSAGE_LENGTH = 64000;
 NetworkEvents::NetworkEvents()
     : GenericProcessor  ("Network Events")
     , Thread            ("NetworkThread")
-    , makeNewSocket     (true)
-    , requestedPort     (5556)
+    , makeNewSocket     (false)
     , boundPort         (0)
 {
     setProcessorType (PROCESSOR_TYPE_SOURCE);
 
+    // async so that any lingering instances will be destroyed first
+    setNewListeningPort(5556, false);
     startThread();
 
     sendSampleCount = false; // disable updating the continuous buffer sample counts,
@@ -51,10 +52,18 @@ NetworkEvents::NetworkEvents()
 }
 
 
-void NetworkEvents::setNewListeningPort(uint16 port)
+void NetworkEvents::setNewListeningPort(uint16 port, bool synchronous)
 {
     requestedPort = port;
-    makeNewSocket = true;
+
+    if (synchronous)
+    {
+        makeNewSocket = true;
+    }
+    else
+    {
+        triggerAsyncUpdate();
+    }
 }
 
 
@@ -107,6 +116,12 @@ AudioProcessorEditor* NetworkEvents::createEditor ()
     editor = new NetworkEventsEditor (this, true);
 
     return editor;
+}
+
+
+void NetworkEvents::handleAsyncUpdate()
+{
+    makeNewSocket = true;
 }
 
 
@@ -437,7 +452,8 @@ void NetworkEvents::loadCustomParametersFromXml()
                 auto port = static_cast<uint16>(mainNode->getIntAttribute("port"));
                 if (port != 0)
                 {
-                    setNewListeningPort(port);
+                    // async so that any lingering instances will be destroyed first
+                    setNewListeningPort(port, false);
                 }
             }
         }

--- a/NetworkEvents/Source/NetworkEvents.h
+++ b/NetworkEvents/Source/NetworkEvents.h
@@ -48,6 +48,7 @@
 */
 class NetworkEvents : public GenericProcessor
                     , public Thread
+                    , private AsyncUpdater
 {
 public:
     NetworkEvents();
@@ -76,7 +77,7 @@ public:
     void run() override;
 
     // passing 0 corresponds to wildcard ("*") and picks any available port
-    void setNewListeningPort (uint16 port);
+    void setNewListeningPort (uint16 port, bool synchronous = true);
 
     // gets a string for the editor's port input to reflect current urlport
     String getCurrPortString() const;
@@ -147,6 +148,8 @@ private:
         
         JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(Responder);
     };
+
+    void handleAsyncUpdate() override; // to change port asynchronously
 
     void postTimestamppedStringToMidiBuffer(const StringTS& s, juce::int64 timestamp);
     


### PR DESCRIPTION
This is a copy of open-ephys/plugin-GUI#282, moved here and updated to eliminate merge conflicts with more recent changes to these plugins. From that PR:

> This fixes the following bug: 
> * You have a signal chain open with one or more Network Events or Event Broadcasters
> * You try to load a new signal chain that has one or more Network Events* or Event Broadcasters bound to the same ports as plugins in the previous chain
> * Those plugins in the new chain are unable to bind to the correct ports, even though they don't conflict with other plugins in the new chain.
> 
> \* I thought I had observed this happening with Network Events previously, but currently it seems to only affect Event Broadcasters.
> 
> This means loading a signal chain is sometimes not an idempotent operation (doing it multiple times does not produce the same result every time), which could be confusing.
> 
> The reason this happens is obscure. The ports that were bound in the old chain should be available again as soon as the old sockets are unbound, which happens as each processor is destroyed. Each processor is removed from the `ProcessorGraph` strictly before the new ones are created when loading a new signal chain. However, the `removeNode` function in `AudioProcessorGraph` does not necessarily destroy  the processor immediately; it asynchronously calls the function `buildRenderingSequence`, and only once this function returns are all the references to the reference-counted `Node` object that owns the processor instance deleted.
> 
> Basically this means that processors are destroyed asynchronously when clearing the chain. (Incidentally, I think this may also explain why loading a signal chain with Rhythm FPGA fails to find the board if there was an instance of the FPGA plugin in the old signal chain.) The solution is to only bind the ports of newly created instances asynchronously. These binding operations should then fall later in the message queue than destroying/unbinding the old instances. I've added `AsyncUpdater` functionality to Network Events and Event Broadcaster so that port changes happen asynchronously during initialization and when loading a signal chain.