### PR TITLE
Add ZMQInterface plugin for interfacing ZeroMQ clients with Open Ephys GUI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.5.0)
 project(OE_ZMQ)
 add_subdirectory(EventBroadcaster)
 add_subdirectory(NetworkEvents)
+add_subdirectory(ZMQInterface)
 
 #on windows, copy the dlls when installing
 if (MSVC)

--- a/ZMQInterface/CMakeLists.txt
+++ b/ZMQInterface/CMakeLists.txt
@@ -1,0 +1,100 @@
+cmake_minimum_required(VERSION 3.5.0)
+if (NOT DEFINED GUI_BASE_DIR)
+	if (DEFINED ENV{GUI_BASE_DIR})
+		set(GUI_BASE_DIR $ENV{GUI_BASE_DIR})
+	else()
+		set(GUI_BASE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../plugin-GUI)
+	endif()
+endif()
+
+get_filename_component(PROJECT_FOLDER ${CMAKE_CURRENT_SOURCE_DIR} ABSOLUTE)
+get_filename_component(PLUGIN_NAME ${PROJECT_FOLDER} NAME)
+
+project(OE_PLUGIN_${PLUGIN_NAME})
+set(CMAKE_SHARED_LIBRARY_PREFIX "")
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+	set(LINUX 1)
+	if(NOT CMAKE_BUILD_TYPE)
+		set(CMAKE_BUILD_TYPE Debug)
+	endif()
+endif()
+
+set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS
+	OEPLUGIN
+	"$<$<PLATFORM_ID:Windows>:JUCE_API=__declspec(dllimport)>"
+	$<$<PLATFORM_ID:Windows>:_CRT_SECURE_NO_WARNINGS>
+	$<$<PLATFORM_ID:Linux>:JUCE_DISABLE_NATIVE_FILECHOOSERS=1>
+	$<$<CONFIG:Debug>:DEBUG=1>
+	$<$<CONFIG:Debug>:_DEBUG=1>
+	$<$<CONFIG:Release>:NDEBUG=1>
+	)
+
+
+set(SOURCE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/Source)
+file(GLOB_RECURSE SRC_FILES LIST_DIRECTORIES false "${SOURCE_PATH}/*.cpp" "${SOURCE_PATH}/*.h")
+set(GUI_COMMONLIB_DIR ${GUI_BASE_DIR}/installed_libs)
+
+set(CONFIGURATION_FOLDER $<$<CONFIG:Debug>:Debug>$<$<NOT:$<CONFIG:Debug>>:Release>)
+
+list(APPEND CMAKE_PREFIX_PATH ${GUI_COMMONLIB_DIR} ${GUI_COMMONLIB_DIR}/${CONFIGURATION_FOLDER})
+
+if (APPLE)
+	add_library(${PLUGIN_NAME} MODULE ${SRC_FILES})
+else()
+	add_library(${PLUGIN_NAME} SHARED ${SRC_FILES})
+endif()
+
+target_compile_features(${PLUGIN_NAME} PUBLIC cxx_auto_type cxx_generalized_initializers)
+target_include_directories(${PLUGIN_NAME} PUBLIC ${GUI_BASE_DIR}/JuceLibraryCode ${GUI_BASE_DIR}/JuceLibraryCode/modules ${GUI_BASE_DIR}/Plugins/Headers ${GUI_COMMONLIB_DIR}/include)
+
+set(GUI_BIN_DIR ${GUI_BASE_DIR}/Build/${CONFIGURATION_FOLDER})
+
+if (NOT CMAKE_LIBRARY_ARCHITECTURE)
+	if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+		set(CMAKE_LIBRARY_ARCHITECTURE "x64")
+	else()
+		set(CMAKE_LIBRARY_ARCHITECTURE "x86")
+	endif()
+endif()
+
+#Libraries and compiler options
+if(MSVC)
+	target_link_libraries(${PLUGIN_NAME} ${GUI_BIN_DIR}/open-ephys.lib)
+	target_compile_options(${PLUGIN_NAME} PRIVATE /sdl-)
+	
+	install(TARGETS ${PLUGIN_NAME} RUNTIME DESTINATION ${GUI_BIN_DIR}/plugins  CONFIGURATIONS ${CMAKE_CONFIGURATION_TYPES})
+
+	set(CMAKE_PREFIX_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../libs)
+elseif(LINUX)
+	target_link_libraries(${PLUGIN_NAME} GL X11 Xext Xinerama asound dl freetype pthread rt)
+	set_property(TARGET ${PLUGIN_NAME} APPEND_STRING PROPERTY LINK_FLAGS
+		"-fvisibility=hidden -fPIC -rdynamic -Wl,-rpath,'$$ORIGIN/../shared'")
+	target_compile_options(${PLUGIN_NAME} PRIVATE -fPIC -rdynamic)
+	target_compile_options(${PLUGIN_NAME} PRIVATE -O3) #enable optimization for linux debug
+	
+	install(TARGETS ${PLUGIN_NAME} LIBRARY DESTINATION ${GUI_BIN_DIR}/plugins)
+elseif(APPLE)
+	set_target_properties(${PLUGIN_NAME} PROPERTIES BUNDLE TRUE)
+	set_property(TARGET ${PLUGIN_NAME} APPEND_STRING PROPERTY LINK_FLAGS
+	"-undefined dynamic_lookup -rpath @loader_path/../../../../shared")
+
+	install(TARGETS ${PLUGIN_NAME} DESTINATION $ENV{HOME}/Library/Application\ Support/open-ephys/PlugIns)
+	set(CMAKE_PREFIX_PATH /opt/local)
+endif()
+
+#create filters for vs and xcode
+
+foreach( src_file IN ITEMS ${SRC_FILES})
+	get_filename_component(src_path "${src_file}" PATH)
+	file(RELATIVE_PATH src_path_rel "${SOURCE_PATH}" "${src_path}")
+	string(REPLACE "/" "\\" group_name "${src_path_rel}")
+	source_group("${group_name}" FILES "${src_file}")
+endforeach()
+
+#additional libraries, if needed
+find_library(ZMQ_LIBRARIES NAMES libzmq-v120-mt-4_0_4 zmq zmq-v120-mt-4_0_4)
+find_path(ZMQ_INCLUDE_DIRS zmq.h)
+
+target_link_libraries(${PLUGIN_NAME} ${ZMQ_LIBRARIES})
+target_include_directories(${PLUGIN_NAME} PRIVATE ${ZMQ_INCLUDE_DIRS})
+target_compile_definitions(${PLUGIN_NAME} PRIVATE ZEROMQ $<$<PLATFORM_ID:Windows>:_SCL_SECURE_NO_WARNINGS>)

--- a/ZMQInterface/Source/OpenEphysLib.cpp
+++ b/ZMQInterface/Source/OpenEphysLib.cpp
@@ -1,0 +1,80 @@
+/*
+ ------------------------------------------------------------------
+ 
+ ZMQInterface
+ Copyright (C) 2016 FP Battaglia
+ 
+ based on
+ Open Ephys GUI
+ Copyright (C) 2013, 2015 Open Ephys
+ 
+ ------------------------------------------------------------------
+ 
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ 
+ */
+
+#include <PluginInfo.h>
+#include <string>
+#ifdef WIN32
+#include <Windows.h>
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+#include "ZmqInterface.h"
+
+
+using namespace Plugin;
+//Number of plugins defined on the library. Can be of different types (Processors, RecordEngines, etc...)
+#define NUM_PLUGINS 1
+
+extern "C" EXPORT void getLibInfo(Plugin::LibraryInfo* info)
+{
+    info->apiVersion = PLUGIN_API_VER; /*API version, defined by the GUI source.
+                                        Should not be changed to ensure it is always equal to the one used in the latest codebase. The GUI refueses to load plugins with mismatched API versions */
+    info->name = "Example library"; //Name of the Library, used only for information
+    info->libVersion = 1; //Version of the library, used only for information
+    info->numPlugins = NUM_PLUGINS;
+}
+
+extern "C" EXPORT int getPluginInfo(int index, Plugin::PluginInfo* info)
+{
+    switch (index)
+    {
+            //one case per plugin. This example is for a processor which connects directly to the signal chain
+        case 0:
+            info->type = PLUGIN_TYPE_PROCESSOR; //Type of plugin. See "Source/Processors/PluginManager/OpenEphysPlugin.h" for complete info about the different type structures
+            //For processor
+            info->processor.name = "ZMQ Interface"; //Processor name shown in the GUI
+            info->processor.type = Plugin::FilterProcessor; //Type of processor. Can be FilterProcessor, SourceProcessor, SinkProcessor or UtilityProcessor. Specifies where on the processor list will appear
+            info->processor.creator = &(Plugin::createProcessor<ZmqInterface>); //Class factory pointer. Replace "ExampleProcessor" with the name of your class.
+            break;
+        default:
+            return -1;
+            break;
+    }
+    return 0;
+}
+
+#ifdef WIN32
+BOOL WINAPI DllMain(IN HINSTANCE hDllHandle,
+                    IN DWORD     nReason,
+                    IN LPVOID    Reserved)
+{
+    return TRUE;
+}
+
+#endif

--- a/ZMQInterface/Source/ZmqInterface.cpp
+++ b/ZMQInterface/Source/ZmqInterface.cpp
@@ -1,0 +1,807 @@
+/*
+ ------------------------------------------------------------------
+ 
+ ZMQInterface
+ Copyright (C) 2016 FP Battaglia
+ Copyright (C) 2017-2019 Andras Szell
+ 
+ based on
+ Open Ephys GUI
+ Copyright (C) 2013, 2015 Open Ephys
+ 
+ ------------------------------------------------------------------
+ 
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ 
+ */
+/* 
+  ==============================================================================
+
+    ZmqInterface.cpp
+    Created: 19 Sep 2015 9:47:12pm
+    Author:  Francesco Battaglia
+    Updated by: Andras Szell
+
+  ==============================================================================
+*/
+
+#include <zmq.h>
+#include <string.h>
+#include <iostream>
+#include <time.h>
+#include <errno.h>
+#include "ZmqInterface.h"
+#include "ZmqInterfaceEditor.h"
+
+#define DEBUG_ZMQ
+const int MAX_MESSAGE_LENGTH = 64000;
+
+struct EventData {
+    uint8 type;
+    uint8 eventId;
+    uint8 eventChannel;
+    uint8 numBytes;
+    int sampleNum;
+    time_t eventTime;
+    char application[256];
+    char uuid[256];
+    bool isEvent;
+};
+
+
+ZmqInterface::ZmqInterface(const String &processorName)
+    : GenericProcessor(processorName), Thread("Zmq thread")
+{
+    context = 0;
+    socket = 0;
+    listenSocket = 0;
+    controlSocket = 0;
+    killSocket = 0;
+    pipeInSocket = 0;
+    pipeOutSocket = 0;
+    
+    flag = 0;
+    messageNumber = 0;
+    dataPort = 5556; //TODO make this editable
+    listenPort = 5557;
+    
+    setProcessorType(PROCESSOR_TYPE_FILTER);
+
+    createContext();
+    threadRunning = false;
+    openListenSocket();
+    openKillSocket();
+    
+    
+    // TODO mock implementation
+//    
+//    ZmqApplication *z = new ZmqApplication();
+//    z->name = String("Mango");
+//    z->alive = true;
+//    z->Uuid = String("bau");
+//    applications.add(z);
+    
+//    z = new ZmqApplication();
+//    z->name = String("Banana");
+//    z->alive = false;
+//    applications.add(z);
+//    
+//    z = new ZmqApplication();
+//    z->name = String("Papaya");
+//    z->alive = true;
+//    applications.add(z);
+
+    
+}
+
+ZmqInterface::~ZmqInterface()
+{
+    threadRunning = false;
+    // send the kill signal to the thread
+    
+    zmq_msg_t messageEnvelope;
+    zmq_msg_init_size(&messageEnvelope, strlen("STOP")+1);
+    memcpy(zmq_msg_data(&messageEnvelope), "STOP", strlen("STOP")+1);
+    zmq_msg_send(&messageEnvelope, killSocket, 0);
+    zmq_msg_close(&messageEnvelope);
+    
+    stopThread(200); // this is probably overkill but won't hurt
+    closeDataSocket();
+    zmq_close(killSocket);
+    zmq_close(pipeOutSocket);
+    
+    sleep(500);
+    
+    if(context)
+    {
+        zmq_ctx_destroy(context);
+        context = 0;
+    }
+}
+
+OwnedArray<ZmqApplication> *ZmqInterface::getApplicationList()
+{
+    return &applications;
+}
+
+int ZmqInterface::createContext()
+{
+    context = zmq_ctx_new();
+    if(!context)
+        return -1;
+    return 0;
+}
+
+int ZmqInterface::createDataSocket()
+{
+    if(!socket)
+    {
+        socket = zmq_socket(context, ZMQ_PUB);
+        if(!socket)
+            return -1;
+        String urlstring;
+        urlstring = String("tcp://*:") + String(dataPort);
+        std::cout << urlstring << std::endl;
+        int rc = zmq_bind(socket, urlstring.toRawUTF8());
+        if(rc)
+        {
+            std::cout << "couldn't open data socket" << std::endl;
+            std::cout << zmq_strerror(zmq_errno()) << std::endl;
+            jassert(false);
+        }
+        
+    }
+    return 0;
+}
+
+int ZmqInterface::closeDataSocket()
+{
+    if(socket)
+    {
+        std::cout << "close data socket" << std::endl;
+        int rc = zmq_close(socket);
+        jassert(rc==0);
+        socket = 0;
+    }
+    return 0;
+}
+
+void ZmqInterface::openListenSocket()
+{
+    startThread();
+}
+
+int ZmqInterface::closeListenSocket()
+{
+    int rc = 0;
+         if(listenSocket)
+        {
+            std::cout << "close listen socket" << std::endl;
+            rc = zmq_close(listenSocket);
+            listenSocket = 0;
+        }
+    
+    return rc;
+}
+
+void ZmqInterface::openKillSocket()
+{
+    killSocket = zmq_socket(context, ZMQ_PAIR);
+    zmq_connect(killSocket, "inproc://zmqthreadcontrol");
+}
+
+void ZmqInterface::openPipeOutSocket()
+{
+    pipeOutSocket = zmq_socket(context, ZMQ_PAIR);
+    zmq_bind(pipeOutSocket, "inproc://zmqthreadpipe");
+}
+
+void ZmqInterface::run()
+{
+    //OutputDebugStringW(L"ZMQ plugin starting.\n");
+    std::cout << "ZMQ plugin starting." << std::endl;
+    listenSocket = zmq_socket(context, ZMQ_REP);
+    String urlstring;
+    urlstring = String("tcp://*:") + String(listenPort);
+    int rc = zmq_bind(listenSocket, urlstring.toRawUTF8()); // give the chance to change the port
+    jassert(rc == 0);
+    threadRunning = true;
+    char* buffer = new char[MAX_MESSAGE_LENGTH];
+
+    int size;
+
+    controlSocket = zmq_socket(context, ZMQ_PAIR);
+    zmq_bind(controlSocket, "inproc://zmqthreadcontrol");
+    
+    pipeInSocket = zmq_socket(context, ZMQ_PAIR);
+    zmq_connect(pipeInSocket, "inproc://zmqthreadpipe");
+    
+    zmq_pollitem_t items [] = {
+        { listenSocket, 0, ZMQ_POLLIN, 0 },
+        { controlSocket, 0, ZMQ_POLLIN, 0 }
+    };
+    
+
+    while(threadRunning && (!threadShouldExit()))
+    {
+        zmq_poll (items, 2, -1);
+        if(items[0].revents & ZMQ_POLLIN)
+        {
+            size = zmq_recv(listenSocket, buffer, MAX_MESSAGE_LENGTH-1, 0);
+            buffer[size] = 0;
+            
+
+            
+            if(size < 0)
+            {
+                std::cout << "failed in receiving listen socket" << std::endl;
+                std::cout << zmq_strerror(zmq_errno()) << std::endl;
+                jassert(false);
+            }
+            var v;
+#ifdef ZMQ_DEBUG
+            std::cout << "in listening thread: " << String(buffer) << std::endl;
+#endif
+            Result rs = JSON::parse(String(buffer), v);
+            bool ok = rs.wasOk();
+
+
+            EventData ed;
+            String app = v["application"];
+            String appUuid = v["uuid"];
+            strncpy(ed.application, app.toRawUTF8(),  255);
+            strncpy(ed.uuid, appUuid.toRawUTF8(), 255);
+            ed.eventTime = time(NULL);
+            
+            String evT = v["type"];
+            
+            if(evT == "event")
+            {
+                ed.isEvent = true;
+                ed.eventChannel = (int)v["event"]["event_channel"];
+                ed.eventId = (int)v["event"]["event_id"];
+                ed.numBytes = 0; // TODO  allow for event data
+                ed.sampleNum = (int)v["event"]["sample_num"];
+                ed.type = (int)v["event"]["type"];
+//                std::cout << "chan " << (int)ed.eventChannel << " id " << (int)ed.eventId << " sample n "
+//                    << (int)ed.sampleNum << " type " << (int)ed.type <<
+//                    std::endl;
+            }
+            else
+            {
+                ed.isEvent = false;
+            }
+            
+            // TODO allow for event data
+            zmq_msg_t message;
+            zmq_msg_init_size(&message, sizeof(EventData));
+            memcpy(zmq_msg_data(&message), &ed, sizeof(EventData));
+            int size_m = zmq_msg_send(&message, pipeInSocket, 0);
+            jassert(size_m);
+            size += size_m;
+            zmq_msg_close(&message);
+            
+            // send response
+            String response;
+            if(ok)
+            {
+                if(ed.isEvent)
+                {
+                    response = String("message correctly parsed");
+                }
+                else
+                {
+                    response = String("heartbeat received");
+                }
+            }
+            else
+            {
+                response = String("JSON message could not be read");
+            }
+            zmq_send(listenSocket, response.getCharPointer(), response.length(), 0);
+            if((!threadRunning) || threadShouldExit())
+                break; // we're exiting
+
+        }
+        else
+            break;
+        
+    }
+    closeListenSocket();
+    
+    zmq_close(pipeInSocket);
+    zmq_close(controlSocket);
+    delete[] buffer;
+    threadRunning = false;
+    return;
+}
+
+/* format for passing data
+ JSON
+ { "messageNo": number,
+ "type": "data"|"event"|"parameter",
+ "content":
+ (for data)
+ { "nChannels": nChannels,
+ "nSamples": nSamples
+ }
+ (for event)
+ {
+ "eventType": number,
+ "sampleNum": sampleNum (number),
+ "eventId": id (number),
+ "eventChannel": channel (number),
+ }
+ (for parameter)
+ {
+ "param_name1": param_value1,
+ "param_name2": param_value2,
+ ...
+ }
+ "dataSize": size (if size > 0 it's the size of binary data coming in in the next frame (multi-part message)
+ }
+ 
+ and then a possible data packet
+ */
+
+
+int ZmqInterface::sendData(float *data, int nChannels, int nSamples, int nRealSamples, int64 timestamp)
+{
+    
+    messageNumber++;
+    
+
+    DynamicObject::Ptr obj = new DynamicObject();
+    
+    int mn = messageNumber;
+    obj->setProperty("message_no", mn);
+    obj->setProperty("type", "data");
+    
+    DynamicObject::Ptr c_obj = new DynamicObject();
+    
+    c_obj->setProperty("n_channels", nChannels);
+    c_obj->setProperty("n_samples", nSamples);
+    c_obj->setProperty("n_real_samples", nRealSamples);
+    c_obj->setProperty("timestamp", timestamp);
+
+    obj->setProperty("content", var(c_obj));
+    obj->setProperty("dataSize", (int)(nChannels * nSamples * sizeof(float)));
+    
+    var json(obj);
+    
+    String s = JSON::toString(json);
+    void *headerData = (void *)s.toRawUTF8();
+    
+
+    size_t headerSize = s.length();
+    
+    zmq_msg_t messageEnvelope;
+    zmq_msg_init_size(&messageEnvelope, strlen("DATA")+1);
+    memcpy(zmq_msg_data(&messageEnvelope), "DATA", strlen("DATA")+1);
+    int size = zmq_msg_send(&messageEnvelope, socket, ZMQ_SNDMORE);
+    jassert(size != -1);
+    zmq_msg_close(&messageEnvelope);
+    
+    zmq_msg_t messageHeader;
+    zmq_msg_init_size(&messageHeader, headerSize);
+    memcpy(zmq_msg_data(&messageHeader), headerData, headerSize);
+    size = zmq_msg_send(&messageHeader, socket, ZMQ_SNDMORE);
+    jassert(size != -1);
+    zmq_msg_close(&messageHeader);
+    
+    zmq_msg_t message;
+    zmq_msg_init_size(&message, sizeof(float)*nSamples*nChannels);
+    memcpy(zmq_msg_data(&message), data, sizeof(float)*nSamples*nChannels);
+    int size_m = zmq_msg_send(&message, socket, 0);
+    jassert(size_m);
+    size += size_m;
+    zmq_msg_close(&message);
+ 
+    return size;
+}
+
+// todo
+int ZmqInterface::sendSpikeEvent(const SpikeChannel* spikeInfo, const MidiMessage &event)
+{
+    messageNumber++;
+    int size = 0;
+
+    const uint8_t* dataptr = event.getRawData();
+    int bufferSize = event.getRawDataSize();
+    if(bufferSize)
+    {
+        SpikeEventPtr spike = SpikeEvent::deserializeFromMessage(event, spikeInfo);
+
+        if (spike)
+        {
+            DynamicObject::Ptr obj = new DynamicObject();
+            obj->setProperty("message_no", messageNumber);
+            obj->setProperty("type", "spike");
+            DynamicObject::Ptr c_obj = new DynamicObject();
+            c_obj->setProperty("timestamp", (int64)spike->getTimestamp());
+            //c_obj->setProperty("timestamp_software",
+            //                 (int64)spike.timestamp_software);
+            const SpikeChannel* channel = spike->getChannelInfo();
+            uint32_t nChannels = channel->getNumChannels();
+            uint32_t nSamples = channel->getTotalSamples();
+            c_obj->setProperty("n_channels", (int64)nChannels);
+            c_obj->setProperty("n_samples", (int64)nSamples);
+    
+            // todo
+            c_obj->setProperty("electrode_id", getSpikeChannelIndex(spike));
+#if 0
+            c_obj->setProperty("channel", spike.channel);
+            c_obj->setProperty("source", spike.source);
+            var c_var(spike.color[0]);
+            c_var.append(spike.color[1]);
+            c_var.append(spike.color[2]);
+            c_obj->setProperty("color", c_var);
+            var p_var(spike.pcProj[0]);
+            p_var.append(spike.pcProj[1]);
+            c_obj->setProperty("pc_proj", p_var);
+            var g_var(spike.gain[0]);
+            for(int i = 1; i < spike.nChannels; i++)
+                g_var.append(spike.gain[i]);
+            c_obj->setProperty("gain", g_var);
+            var t_var = var(spike.threshold[0]);
+            for(int i = 1; i < spike.nChannels; i++)
+                t_var.append(spike.threshold[i]);
+            c_obj->setProperty("threshold", t_var);
+#endif
+            obj->setProperty("spike", var(c_obj));
+            var json (obj);
+            String s = JSON::toString(json);
+            void *headerData = (void *)s.toRawUTF8();
+            size_t headerSize = s.length();
+            
+            
+            zmq_msg_t messageEnvelope;
+            zmq_msg_init_size(&messageEnvelope, strlen("EVENT")+1);
+            memcpy(zmq_msg_data(&messageEnvelope), "EVENT", strlen("EVENT")+1);
+            size = zmq_msg_send(&messageEnvelope, socket, ZMQ_SNDMORE);
+            jassert(size != -1);
+            zmq_msg_close(&messageEnvelope);
+
+            zmq_msg_t messageHeader;
+            zmq_msg_init_size(&messageHeader, headerSize);
+            memcpy(zmq_msg_data(&messageHeader), headerData, headerSize);
+            size = zmq_msg_send(&messageHeader, socket, ZMQ_SNDMORE);
+            jassert(size != -1);
+            zmq_msg_close(&messageHeader);
+            zmq_msg_t message;
+            zmq_msg_init_size(&message, nChannels * nSamples);
+            // getdatapointer???
+            memcpy(zmq_msg_data(&message), spike->getDataPointer(), nChannels * nSamples);
+            size = zmq_msg_send(&message, socket, 0);
+            
+        }
+    }
+    return 0;
+}
+
+int ZmqInterface::sendEvent( uint8 type,
+                             int sampleNum,
+                             uint8 eventId,
+                             uint8 eventChannel,
+                             uint8 numBytes,
+                             const uint8* eventData,
+                             int64 timestamp)
+{
+    int size;
+    
+    messageNumber++;
+    
+    DynamicObject::Ptr obj = new DynamicObject();
+    
+    obj->setProperty("message_no", messageNumber);
+    obj->setProperty("type", "event");
+    
+    DynamicObject::Ptr c_obj = new DynamicObject();
+    c_obj->setProperty("type", type);
+    c_obj->setProperty("sample_num", sampleNum);
+    c_obj->setProperty("event_id", eventId);
+    c_obj->setProperty("event_channel", eventChannel);
+    c_obj->setProperty("timestamp", timestamp);
+
+    obj->setProperty("content", var(c_obj));
+    obj->setProperty("data_size", numBytes);
+    
+    var json (obj);
+    String s = JSON::toString(json);
+    void *headerData = (void *)s.toRawUTF8();
+    size_t headerSize = s.length();
+    
+    
+    zmq_msg_t messageEnvelope;
+    zmq_msg_init_size(&messageEnvelope, strlen("EVENT")+1);
+    memcpy(zmq_msg_data(&messageEnvelope), "EVENT", strlen("EVENT")+1);
+    size = zmq_msg_send(&messageEnvelope, socket, ZMQ_SNDMORE);
+    jassert(size != -1);
+    zmq_msg_close(&messageEnvelope);
+    
+    zmq_msg_t messageHeader;
+    zmq_msg_init_size(&messageHeader, headerSize);
+    memcpy(zmq_msg_data(&messageHeader), headerData, headerSize);
+    if(numBytes == 0)
+    {
+        size = zmq_msg_send(&messageHeader, socket, 0);
+        jassert(size != -1);
+        zmq_msg_close(&messageHeader);
+    }
+    else
+    {
+        size = zmq_msg_send(&messageHeader, socket, ZMQ_SNDMORE);
+        jassert(size != -1);
+        zmq_msg_close(&messageHeader);
+        zmq_msg_t message;
+        zmq_msg_init_size(&message, numBytes);
+        memcpy(zmq_msg_data(&message), eventData, numBytes);
+        int size_m = zmq_msg_send(&message, socket, 0);
+        jassert(size_m);
+        size += size_m;
+        zmq_msg_close(&message);
+    }
+    return size;
+}
+
+template<typename T> int ZmqInterface::sendParam(String name, T value)
+{
+    int size;
+    
+    messageNumber++;
+    
+//    MemoryOutputStream jsonHeader;
+//    jsonHeader << "{ \"messageNo\": " << messageNumber << "," << newLine;
+//    jsonHeader << "  \"type\": \"param\"," << newLine;
+//    jsonHeader << " \"content\": " << newLine;
+//    jsonHeader << " { \"" << name << "\": " << value  << newLine;
+//    jsonHeader << "}," << newLine;
+//    jsonHeader << " \"dataSize\": " << 0 << newLine;
+//    jsonHeader << "}";
+    
+    
+    DynamicObject::Ptr obj = new DynamicObject();
+    
+    obj->setProperty("message_no", messageNumber);
+    obj->setProperty("type", "event");
+    DynamicObject::Ptr c_obj = new DynamicObject();
+    c_obj->setProperty(name, value);
+    
+    obj->setProperty("content", var(c_obj));
+    obj->setProperty("data_size", 0);
+    
+    var json (obj);
+    String s = JSON::toString(json);
+    void *headerData = (void *)s.toRawUTF8();
+    size_t headerSize = s.length();
+    
+    zmq_msg_t messageEnvelope;
+    zmq_msg_init_size(&messageEnvelope, strlen("PARAM")+1);
+    memcpy(zmq_msg_data(&messageEnvelope), "PARAM", strlen("PARAM")+1);
+    size = zmq_msg_send(&messageEnvelope, socket, ZMQ_SNDMORE);
+    jassert(size != -1);
+    zmq_msg_close(&messageEnvelope);
+    
+    
+    zmq_msg_t messageHeader;
+    zmq_msg_init_size(&messageHeader, headerSize);
+    memcpy(zmq_msg_data(&messageHeader), headerData, headerSize);
+    size = zmq_msg_send(&messageHeader, socket, 0);
+    jassert(size != -1);
+    zmq_msg_close(&messageHeader);
+    
+    return size;
+}
+
+
+AudioProcessorEditor* ZmqInterface::createEditor()
+{
+    
+    //        std::cout << "in PythonEditor::createEditor()" << std::endl;
+    editor = new ZmqInterfaceEditor(this, true);
+    return editor;
+}
+
+bool ZmqInterface::isReady()
+{
+    return true;
+}
+
+void ZmqInterface::setParameter(int parameterIndex, float newValue)
+{
+    editor->updateParameterButtons(parameterIndex);
+    
+    //Parameter& p =  parameters.getReference(parameterIndex);
+    //p.setValue(newValue, 0);
+    
+    //threshold = newValue;
+    
+    //std::cout << float(p[0]) << std::endl;
+    editor->updateParameterButtons(parameterIndex);
+}
+
+void ZmqInterface::resetConnections()
+{
+    nextAvailableChannel = 0;
+    
+    wasConnected = false;
+
+    return;
+}
+
+void ZmqInterface::handleEvent(const EventChannel* eventInfo, const MidiMessage& event, int samplePosition)
+{
+    //std::cout << "Event handling, type: " << Event::getEventType(event) << "\n" << std::flush;
+
+    if (Event::getEventType(event) == EventChannel::TTL)
+    {
+        TTLEventPtr ttl = TTLEvent::deserializeFromMessage(event, eventInfo);
+
+        const uint8* dataptr = event.getRawData();
+        int size = event.getRawDataSize();
+        //std::cout << "event data size " << size << std::endl;
+        uint8 numBytes;
+        if (size > 6)
+            numBytes = size - 6;
+        else
+            numBytes = 0;
+
+
+        //int eventNodeId = *(dataptr+1);
+        const int eventId = ttl->getState() ? 1 : 0;
+        const int eventChannel = ttl->getChannel();
+        //const int eventTime = samplePosition;
+        //std::cout << "ZMQ TTL timestamp " << event.getTimeStamp() << " samplepos " << samplePosition << std::endl << std::flush;
+        //std::cout << "TTL TS " << *(uint64_t*)(dataptr + 8) << " vs " << ttl->getTimestamp() << " vs " << event.getTimeStamp() << std::endl;
+
+        sendEvent(Event::getEventType(event),
+            samplePosition,
+            eventId,
+            eventChannel,
+            numBytes,
+            dataptr + 6,
+            ttl->getTimestamp()); // there should be a better way... getTimeStamp()??
+    }
+}
+
+void ZmqInterface::handleSpike(const SpikeChannel* spikeInfo, const MidiMessage& event, int samplePosition)
+{
+    std::cout << "spike" << std::endl;
+    sendSpikeEvent(spikeInfo, event);
+}
+
+int ZmqInterface::receiveEvents(MidiBuffer &events)
+{
+    
+    EventData ed;
+    while(true)
+    {
+        int size = zmq_recv(pipeOutSocket, &ed, sizeof(ed), ZMQ_DONTWAIT);
+        if(size == -1)
+        {
+            if(zmq_errno() == EAGAIN)
+            {
+                break;
+            }
+            else
+            {
+                std::cout << "pipe out error: " << zmq_strerror(zmq_errno()) << std::endl;
+            }
+        }
+//        std::cout << "adding events" << std::endl;
+//        std::cout << "chan " << (int)ed.eventChannel << " id " << (int)ed.eventId << " sample n "
+//        << (int)ed.sampleNum << " type " << (int)ed.type <<
+//        std::endl;
+        
+        int appNo = -1;
+        for(int i = 0; i < applications.size(); i++)
+        {
+            ZmqApplication *app = applications[i];
+            if(app->Uuid == String(ed.uuid))
+            {
+                bool refreshEd = false;
+                appNo = i;
+                app->lastSeen = ed.eventTime;
+                if(!app->alive)
+                    refreshEd = true;
+                app->alive = true;
+                ZmqInterfaceEditor *zed =    dynamic_cast<ZmqInterfaceEditor *> (getEditor());
+                zed->refreshListAsync();
+
+                break;
+            }
+        }
+
+        if(appNo == -1)
+        {
+            ZmqApplication *app = new ZmqApplication;
+            app->name = String(ed.application);
+            app->Uuid = String(ed.uuid);
+            app->lastSeen = ed.eventTime;
+            app->alive = true;
+            applications.add(app);
+            std::cout << "adding new application " << app->name << " " << app->Uuid << std::endl;
+            std::cout << " now there are " << applications.size() << " apps" << std::endl;
+            ZmqInterfaceEditor *zed =    dynamic_cast<ZmqInterfaceEditor *> (getEditor());
+            zed->refreshListAsync();
+//            MessageManagerLock mmlock;
+//            editor->repaint();
+    
+        }
+
+
+        if (ed.isEvent) {
+            std::cout << "ZMQ event received\n";
+        }
+#if 0
+        if (ed.isEvent) {
+            addEvent(events, ed.type, ed.sampleNum, ed.eventId, ed.eventChannel, ed.numBytes, NULL, false);
+        }
+
+
+        //void addEvent(int channelIndex, const Event* event, int sampleNum);
+        //void addEvent(const EventChannel* channel, const Event* event, int sampleNum);
+        // TODO allow for event data
+#endif
+    }
+
+    return 0;
+}
+
+void ZmqInterface::checkForApplications()
+{
+    time_t timeNow = time(NULL);
+    for(int i = 0; i < applications.size(); i++)
+    {
+        ZmqApplication *app = applications[i];
+        if((timeNow - app->lastSeen) > 10 && app->alive)
+        {
+            app->alive = false;
+            std::cout << "app " << app->name << " not alive" << std::endl;
+            ZmqInterfaceEditor *zed =    dynamic_cast<ZmqInterfaceEditor *> (getEditor());
+            zed->refreshListAsync();
+        }
+    }
+
+}
+
+void ZmqInterface::process(AudioSampleBuffer& buffer)
+{
+    if(!socket)
+        createDataSocket();
+    
+    if(!pipeOutSocket)
+        openPipeOutSocket();
+
+    checkForEvents(true); // see if we got any TTL events
+
+    // current timestamp is at the end of the buffer; we want to send the timestamp of the first sample instead
+    uint64_t firstTs = getTimestamp(0) - getNumSamples(0);
+
+    sendData(*(buffer.getArrayOfWritePointers()), buffer.getNumChannels(), 
+        buffer.getNumSamples(), getNumSamples(0), firstTs);
+
+#if 0
+    receiveEvents(events);
+#endif
+    checkForApplications();
+    
+}
+
+void ZmqInterface::updateSettings()
+{
+    
+}
+
+

--- a/ZMQInterface/Source/ZmqInterface.h
+++ b/ZMQInterface/Source/ZmqInterface.h
@@ -1,0 +1,175 @@
+/*
+ ------------------------------------------------------------------
+ 
+ ZMQInterface
+ Copyright (C) 2016 FP Battaglia
+ 
+ based on
+ Open Ephys GUI
+ Copyright (C) 2013, 2015 Open Ephys
+ 
+ ------------------------------------------------------------------
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ 
+ */
+/*
+  ==============================================================================
+
+    ZmqInterface.h
+    Created: 19 Sep 2015 9:47:12pm
+    Author:  Francesco Battaglia
+
+  ==============================================================================
+*/
+
+#ifndef ZMQINTERFACE_H_INCLUDED
+#define ZMQINTERFACE_H_INCLUDED
+
+
+#include <ProcessorHeaders.h>
+
+#include <queue>
+
+
+struct ZmqApplication {
+    String name;
+    String Uuid;
+    time_t lastSeen;
+    bool alive;
+};
+
+
+//=============================================================================
+/*
+ */
+class ZmqInterface    : public GenericProcessor, public Thread
+{
+public:
+    /** The class constructor, used to initialize any members. */
+    ZmqInterface(const String &processorName = "Zmq Interface");
+    
+    /** The class destructor, used to deallocate memory */
+    ~ZmqInterface();
+    
+    /** Determines whether the processor is treated as a source. */
+    virtual bool isSource()
+    {
+        return false;
+    }
+    
+    /** Determines whether the processor is treated as a sink. */
+    virtual bool isSink()
+    {
+        return false;
+    }
+    
+    /** Defines the functionality of the processor.
+     
+     The process method is called every time a new data buffer is available.
+     
+     Processors can either use this method to add new data, manipulate existing
+     data, or send data to an external target (such as a display or other hardware).
+     
+     Continuous signals arrive in the "buffer" variable, event data (such as TTLs
+     and spikes) is contained in the "events" variable, and "nSamples" holds the
+     number of continous samples in the current buffer (which may differ from the
+     size of the buffer).
+     */
+    //virtual void process(AudioSampleBuffer& buffer, MidiBuffer& events);
+    virtual void process(AudioSampleBuffer& continuousBuffer);
+    
+    /** Any variables used by the "process" function _must_ be modified only through
+     this method while data acquisition is active. If they are modified in any
+     other way, the application will crash.  */
+    void setParameter(int parameterIndex, float newValue);
+    
+    AudioProcessorEditor* createEditor();
+    
+    bool hasEditor() const
+    {
+        return true;
+    }
+    
+    void updateSettings();
+    
+    bool isReady();
+    
+    void resetConnections();
+    void run();
+
+    OwnedArray<ZmqApplication> *getApplicationList();
+
+    // TODO void saveCustomParametersToXml(XmlElement* parentElement);
+    // TODO void loadCustomParametersFromXml();
+
+    bool threadRunning ;
+    // TODO void setNewListeningPort(int port);
+#if 0
+    void setPorts(uint32_t newDataPort, uint32_t newListenPort);
+    uint32_t getDataPort () const { return dataPort; }
+    uint32_t getListenPort () const { return listenPort; }
+#endif
+
+private:
+    int createContext();
+    void openListenSocket();
+    void openKillSocket();
+    void openPipeOutSocket();
+    int closeListenSocket();
+    int createDataSocket();
+    int closeDataSocket();
+
+    void handleEvent(const EventChannel* eventInfo, const MidiMessage& event, int samplePosition);
+    void handleSpike(const SpikeChannel* spikeInfo, const MidiMessage& event, int samplePosition);
+    int sendData(float *data, int nChannels, int nSamples, int nRealSamples, int64 timestamp);
+    int sendEvent( uint8 type,
+                  int sampleNum,
+                  uint8 eventId,
+                  uint8 eventChannel,
+                  uint8 numBytes,
+                  const uint8* eventData,
+                  int64 timestamp);
+    int sendSpikeEvent(const SpikeChannel* spikeInfo, const MidiMessage &event);
+    
+    int receiveEvents(MidiBuffer &events);
+    void checkForApplications();
+    
+    template<typename T> int sendParam(String name, T value);
+
+    
+    void *context;
+    void *socket;
+    void *listenSocket;
+    void *controlSocket;
+    void *killSocket;
+    void *pipeInSocket;
+    void *pipeOutSocket;
+    
+    
+    OwnedArray<ZmqApplication> applications;
+    
+    int flag;
+    int messageNumber;
+    int dataPort; //TODO make this editable
+    int listenPort;
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ZmqInterface);
+    
+};
+
+
+
+
+
+
+#endif  // ZMQINTERFACE_H_INCLUDED

--- a/ZMQInterface/Source/ZmqInterfaceEditor.cpp
+++ b/ZMQInterface/Source/ZmqInterfaceEditor.cpp
@@ -1,0 +1,214 @@
+/*
+ ------------------------------------------------------------------
+ 
+ ZMQInterface
+ Copyright (C) 2016 FP Battaglia
+ 
+ based on
+ Open Ephys GUI
+ Copyright (C) 2013, 2015 Open Ephys
+ 
+ ------------------------------------------------------------------
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ 
+ */
+
+/*
+  ==============================================================================
+
+    ZmqInterfaceEditor.cpp
+    Created: 22 Sep 2015 9:42:44am
+    Author:  Francesco Battaglia
+
+  ==============================================================================
+*/
+
+
+
+
+#include "ZmqInterfaceEditor.h"
+#include "ZmqInterface.h"
+
+class ZmqInterfaceEditor::ZmqInterfaceEditorListBox: public ListBox,
+private ListBoxModel, public AsyncUpdater
+{
+public:
+    ZmqInterfaceEditorListBox(const String noItemsText, ZmqInterfaceEditor *e):
+    ListBox(String::empty, nullptr), noItemsMessage(noItemsText)
+    {
+        editor = e;
+        setModel(this);
+        
+        backgroundGradient = ColourGradient(Colour(190, 190, 190), 0.0f, 0.0f,
+                                            Colour(185, 185, 185), 0.0f, 120.0f, false);
+        backgroundGradient.addColour(0.2f, Colour(155, 155, 155));
+        
+        backgroundColor = Colour(155, 155, 155);
+        
+        setColour(backgroundColourId, backgroundColor);
+        
+        refresh();
+
+    }
+    
+    void handleAsyncUpdate()
+    {
+        refresh();
+    }
+    
+    void refresh()
+    {
+        updateContent();
+        repaint();
+        
+    }
+    
+    int getNumRows() override
+    {
+        return editor->getApplicationList()->size();
+    }
+    
+    
+    void paintListBoxItem (int row, Graphics& g, int width, int height, bool rowIsSelected) override
+    {
+        OwnedArray<ZmqApplication> *items = editor->getApplicationList();
+        if (isPositiveAndBelow (row, items->size()))
+        {
+            g.fillAll(Colour(155, 155, 155));
+            if (rowIsSelected)
+                g.fillAll (findColour (TextEditor::highlightColourId)
+                           .withMultipliedAlpha (0.3f));
+            
+            ZmqApplication *i = (*items)[row];
+            const String item (i->name); // TODO change when we put a map
+                
+            const int x = getTickX();
+            
+            g.setFont (height * 0.6f);
+            if(i->alive)
+                g.setColour(Colours::green);
+            else
+                g.setColour(Colours::red);
+            g.drawText (item, x, 0, width - x - 2, height, Justification::centredLeft, true);
+        } // end of function
+    }
+    
+    
+    void listBoxItemClicked (int row, const MouseEvent& e) override
+    {
+        selectRow (row);
+    }
+    
+    void paint (Graphics& g) override
+    {
+        ListBox::paint (g);
+        g.setColour (Colours::grey);
+        g.setGradientFill(backgroundGradient);
+        if (editor->getApplicationList()->size() == 0)
+        {
+            g.setColour (Colours::grey);
+            g.setFont (13.0f);
+            g.drawText (noItemsMessage,
+                        0, 0, getWidth(), getHeight() / 2,
+                        Justification::centred, true);
+        }
+    }
+    
+    
+    
+    
+private:
+    const String noItemsMessage;
+    ZmqInterfaceEditor *editor;
+    /** Stores the editor's background color. */
+    Colour backgroundColor;
+    
+    /** Stores the editor's background gradient. */
+    ColourGradient backgroundGradient;
+    
+    int getTickX() const
+    {
+        return getRowHeight() + 5;
+    }
+    
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (ZmqInterfaceEditorListBox)
+};
+
+ZmqInterfaceEditor::ZmqInterfaceEditor(GenericProcessor *parentNode, bool useDefaultParameters): GenericEditor(parentNode, useDefaultParameters)
+{
+    ZmqProcessor = (ZmqInterface *)parentNode;
+    listBox = new ZmqInterfaceEditorListBox(String("no app connected"), this);
+    listBox->setBounds(2,25,130,105);
+    addAndMakeVisible(listBox);
+#if 0
+    dataPortEditor = new TextEditor("dataport");
+    addAndMakeVisible(dataPortEditor);
+    dataPortEditor->setBounds(10, 110, 40, 16);
+    dataPortEditor->setText(String(ZmqProcessor->getDataPort()));
+
+	portButton = new TextButton("set_ports");
+    addAndMakeVisible(portButton);
+    portButton->setBounds(90, 110, 40, 16);
+    portButton->setButtonText("set ports");
+    portButton->addListener(this);
+#endif
+    setEnabledState(false);
+}
+
+ZmqInterfaceEditor::~ZmqInterfaceEditor()
+{
+    deleteAllChildren();
+}
+
+void ZmqInterfaceEditor::saveCustomParameters(XmlElement *xml)
+{
+    // todo: ports    
+}
+
+void ZmqInterfaceEditor::loadCustomParameters(XmlElement* xml)
+{
+    // todo: ports
+}
+
+void ZmqInterfaceEditor::refreshListAsync()
+{
+    listBox->triggerAsyncUpdate();
+}
+
+OwnedArray<ZmqApplication> *ZmqInterfaceEditor::getApplicationList()
+{
+    OwnedArray<ZmqApplication> *ar = ZmqProcessor->getApplicationList();
+    return ar;
+    
+}
+
+#if 0
+void ZmqInterfaceEditor::buttonClicked(Button* button)
+{
+    if (button == portButton)
+    {
+        String dport = dataPortEditor->getText();
+        int dportVal = dport.getIntValue();
+        if ( (dportVal == 0) && !dport.containsOnly("0")) {
+            // wrong integer input
+            CoreServices::sendStatusMessage("Invalid data port value");
+            dataPortEditor->setText(String(ZmqProcessor->getDataPort()));
+        } else {
+            ZmqProcessor->setPorts(dportVal, dportVal + 1);
+            CoreServices::sendStatusMessage("ZMQ ports updated");
+        }
+    }
+}
+#endif
+

--- a/ZMQInterface/Source/ZmqInterfaceEditor.h
+++ b/ZMQInterface/Source/ZmqInterfaceEditor.h
@@ -1,0 +1,74 @@
+/*
+ ------------------------------------------------------------------
+ 
+ ZMQInterface
+ Copyright (C) 2016 FP Battaglia
+ 
+ based on
+ Open Ephys GUI
+ Copyright (C) 2013, 2015 Open Ephys
+ 
+ ------------------------------------------------------------------
+ 
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ 
+ */
+
+
+/*
+  ==============================================================================
+
+    ZmqInterfaceEditor.h
+    Created: 22 Sep 2015 9:42:44am
+    Author:  Francesco Battaglia
+
+  ==============================================================================
+*/
+
+#ifndef ZMQINTERFACEEDITOR_H_INCLUDED
+#define ZMQINTERFACEEDITOR_H_INCLUDED
+
+#include <EditorHeaders.h>
+class ZmqInterface;
+
+struct ZmqApplication;
+
+class ZmqInterfaceEditor: public GenericEditor
+{
+public:
+    ZmqInterfaceEditor(GenericProcessor *parentNode, bool useDefaultParameters);
+    virtual ~ZmqInterfaceEditor();
+    void saveCustomParameters(XmlElement *xml);
+    void loadCustomParameters(XmlElement* xml);
+    void refreshListAsync();
+#if 0
+    void setPorts(uint32_t dataPort, uint32_t listenPort, void callback());
+    void buttonClicked(Button* button) override;
+#endif
+private:
+    //TODO UI components
+    class ZmqInterfaceEditorListBox;
+#if 0
+    TextEditor *dataPortEditor, *listenPortEditor;
+    TextButton *portButton;
+#endif
+    OwnedArray<ZmqApplication> *getApplicationList();
+    ZmqInterface *ZmqProcessor;
+    ZmqInterfaceEditorListBox *listBox;
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (ZmqInterfaceEditor)
+
+    
+};
+
+#endif  // ZMQINTERFACEEDITOR_H_INCLUDED


### PR DESCRIPTION
- A plugin for open-ephys enabling the interfacing of ZeroMQ clients to open ephys.

- The interface exposes all data and events and allows to provide events to the application, enabling the creation of advanced visualization and monitoring add-ons.

- Originally developed by @MemDynLab and modified by @bandita137 (https://github.com/bandita137/ZMQInterface)

- Tested with Windows 10 & Linux (Ubuntu 19.04) systems